### PR TITLE
refactor: DRY cleanup, tests, SSHW_SSH_CONFIG_PATH, README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,5 +41,11 @@ jobs:
       - name: Build
         run: go build -v ./cmd/sshw/main.go
 
-      - name: Run tests
-        run: go test -v ./...
+      - name: Test
+        shell: bash
+        run: |
+          if command -v make >/dev/null 2>&1; then
+            make test
+          else
+            go test -count=1 ./...
+          fi

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ BINARY := sshw
 VERSION := $(shell git describe --tags --always --dirty)
 LDFLAGS := -s -w -X main.Build=$(VERSION)
 
-.PHONY: build clean install lint
+.PHONY: build clean install lint test
 
 build:
 	CGO_ENABLED=0 go build -trimpath -ldflags '$(LDFLAGS)' -o $(BINARY) ./cmd/sshw
@@ -15,3 +15,6 @@ clean:
 
 lint:
 	golangci-lint run ./...
+
+test:
+	go test -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or download binary from [releases](//github.com/yinheli/sshw/releases).
 
 ## config
 
-config file load in following order:
+If `SSHW_CONFIG_PATH` is set to a file path, only that file is tried for the YAML config (see `LoadConfig` in code). Otherwise the config file load order is:
 
 - `~/.sshw`
 - `~/.sshw.yml`
@@ -26,6 +26,12 @@ config file load in following order:
 - `./.sshw`
 - `./.sshw.yml`
 - `./.sshw.yaml`
+
+When using the `-s` flag (read OpenSSH `~/.ssh/config` instead of YAML), the path defaults to `~/.ssh/config`. You can override it with **`SSHW_SSH_CONFIG_PATH`**, for example to point at a non-standard location or a copy for testing:
+
+```bash
+SSHW_SSH_CONFIG_PATH=/path/to/ssh_config sshw -s
+```
 
 config example:
 

--- a/client.go
+++ b/client.go
@@ -19,6 +19,13 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+func parseSigner(pemBytes []byte, passphrase string) (ssh.Signer, error) {
+	if passphrase != "" {
+		return ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(passphrase))
+	}
+	return ssh.ParsePrivateKey(pemBytes)
+}
+
 var (
 	DefaultCiphers = []string{
 		"aes128-ctr",
@@ -93,12 +100,7 @@ func setupKeyFileAuth(node *Node) (ssh.AuthMethod, cleanupFunc, error) {
 		return nil, nil, err
 	}
 
-	var signer ssh.Signer
-	if node.Passphrase != "" {
-		signer, err = ssh.ParsePrivateKeyWithPassphrase(bytes, []byte(node.Passphrase))
-	} else {
-		signer, err = ssh.ParsePrivateKey(bytes)
-	}
+	signer, err := parseSigner(bytes, node.Passphrase)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -113,13 +115,7 @@ func setupDefaultKeyAuth(node *Node) (ssh.AuthMethod, cleanupFunc, error) {
 	keyPath := filepath.Join(u.HomeDir, ".ssh/id_rsa")
 	bytes, err := os.ReadFile(keyPath)
 	if err == nil && len(bytes) > 0 {
-		var signer ssh.Signer
-		if node.Passphrase != "" {
-			signer, err = ssh.ParsePrivateKeyWithPassphrase(bytes, []byte(node.Passphrase))
-		} else {
-			signer, err = ssh.ParsePrivateKey(bytes)
-		}
-		if err == nil {
+		if signer, err := parseSigner(bytes, node.Passphrase); err == nil {
 			return ssh.PublicKeys(signer), nil, nil
 		}
 	}
@@ -224,6 +220,7 @@ func (c *defaultClient) Login() {
 	if len(jNodes) > 0 {
 		jNode := jNodes[0]
 		jc := genSSHConfig(jNode)
+		defer jc.close()
 		proxyClient, err := ssh.Dial("tcp", net.JoinHostPort(jNode.Host, strconv.Itoa(jNode.port())), jc.clientConfig)
 		if err != nil {
 			l.Error(err)

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,36 @@
+package sshw
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+func TestParseSigner_rsa(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}
+	pemBytes := pem.EncodeToMemory(block)
+
+	s, err := parseSigner(pemBytes, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil {
+		t.Fatal("nil signer")
+	}
+}
+
+func TestParseSigner_invalidPEM(t *testing.T) {
+	t.Parallel()
+	_, err := parseSigner([]byte("not a pem block"), "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/sshw/main.go
+++ b/cmd/sshw/main.go
@@ -19,13 +19,6 @@ var (
 	log = sshw.GetLogger()
 )
 
-func connectableDisplayUser(n *sshw.Node) string {
-	if n.User != "" {
-		return n.User
-	}
-	return "root"
-}
-
 func main() {
 	flag.Parse()
 	if !flag.Parsed() {
@@ -76,7 +69,7 @@ func main() {
 		default:
 			fmt.Fprintf(os.Stderr, "ambiguous name or alias %q (%d matches):\n", token, len(matches))
 			for i, n := range matches {
-				fmt.Fprintf(os.Stderr, "  %d) %s @ %s (%s)\n", i+1, connectableDisplayUser(n), n.Host, n.Name)
+				fmt.Fprintf(os.Stderr, "  %d) %s @ %s (%s)\n", i+1, n.EffectiveUser(), n.Host, n.Name)
 			}
 			os.Exit(1)
 		}

--- a/config.go
+++ b/config.go
@@ -2,16 +2,14 @@ package sshw
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 	"strconv"
 	"time"
 
 	"github.com/atrox/homedir"
 	"github.com/kevinburke/ssh_config"
-	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
 )
 
@@ -76,15 +74,26 @@ func (n *Node) port() int {
 	return n.Port
 }
 
-func (n *Node) password() ssh.AuthMethod {
-	if n.Password == "" {
-		return nil
-	}
-	return ssh.Password(n.Password)
+// EffectiveUser returns User, or "root" when empty (same rule as SSH client config).
+func (n *Node) EffectiveUser() string {
+	return n.user()
 }
 
-func (n *Node) alias() string {
-	return n.Alias
+// SSHPort returns Port, or 22 when unset or non-positive.
+func (n *Node) SSHPort() int {
+	return n.port()
+}
+
+// JumpLabel returns the first jump hop's Name, or Host if Name is empty; empty if there is no jump.
+func (n *Node) JumpLabel() string {
+	if len(n.Jump) == 0 {
+		return ""
+	}
+	j := n.Jump[0]
+	if j.Name != "" {
+		return j.Name
+	}
+	return j.Host
 }
 
 var (
@@ -117,15 +126,31 @@ func LoadConfig() error {
 }
 
 func LoadSshConfig() error {
-	u, err := user.Current()
-	if err != nil {
-		l.Error(err)
-		return nil
+	var p string
+	if ep := os.Getenv("SSHW_SSH_CONFIG_PATH"); ep != "" {
+		p = ep
+	} else {
+		u, err := user.Current()
+		if err != nil {
+			l.Error(err)
+			return err
+		}
+		p = filepath.Join(u.HomeDir, ".ssh", "config")
 	}
-	f, _ := os.Open(path.Join(u.HomeDir, ".ssh/config"))
+	f, err := os.Open(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			config = nil
+			return nil
+		}
+		return err
+	}
 	defer f.Close()
 
-	cfg, _ := ssh_config.Decode(f)
+	cfg, err := ssh_config.Decode(f)
+	if err != nil {
+		return err
+	}
 	var nc []*Node
 	for _, host := range cfg.Hosts {
 		alias := fmt.Sprintf("%s", host.Patterns[0])
@@ -161,19 +186,22 @@ func LoadConfigBytes(names ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	var lastErr error
 	// homedir
 	for i := range names {
-		sshw, err := ioutil.ReadFile(path.Join(u.HomeDir, names[i]))
+		sshw, err := os.ReadFile(filepath.Join(u.HomeDir, names[i]))
 		if err == nil {
 			return sshw, nil
 		}
+		lastErr = err
 	}
 	// relative
 	for i := range names {
-		sshw, err := ioutil.ReadFile(names[i])
+		sshw, err := os.ReadFile(names[i])
 		if err == nil {
 			return sshw, nil
 		}
+		lastErr = err
 	}
-	return nil, err
+	return nil, lastErr
 }

--- a/config_ssh_test.go
+++ b/config_ssh_test.go
@@ -1,0 +1,46 @@
+package sshw
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadSshConfig_missingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "no-ssh-config")
+	t.Setenv("SSHW_SSH_CONFIG_PATH", missing)
+	if err := LoadSshConfig(); err != nil {
+		t.Fatal(err)
+	}
+	if GetConfig() != nil {
+		t.Fatalf("expected nil config when ~/.ssh/config is absent")
+	}
+}
+
+func TestLoadSshConfig_readsHost(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "config")
+	content := "Host mybox\n  HostName 10.0.0.5\n  User deploy\n  Port 2222\n"
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SSHW_SSH_CONFIG_PATH", p)
+	if err := LoadSshConfig(); err != nil {
+		t.Fatal(err)
+	}
+	nodes := GetConfig()
+	if len(nodes) == 0 {
+		t.Fatal("expected at least one node")
+	}
+	var found bool
+	for _, n := range nodes {
+		if strings.Contains(n.Host, "10.0.0.5") && n.EffectiveUser() == "deploy" && n.SSHPort() == 2222 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("parsed nodes missing expected host: %#v", nodes)
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,158 @@
+package sshw
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNode_Connectable(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		node *Node
+		want bool
+	}{
+		{"leaf_with_host", &Node{Host: "h.example", Name: "n"}, true},
+		{"no_host", &Node{Name: "n"}, false},
+		{"host_but_has_children", &Node{Host: "h", Children: []*Node{{Name: "c"}}}, false},
+		{"empty_children_leaf", &Node{Host: "h", Children: nil}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.node.Connectable(); got != tc.want {
+				t.Fatalf("Connectable() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNode_user_port(t *testing.T) {
+	t.Parallel()
+	n := &Node{}
+	if got := n.user(); got != "root" {
+		t.Fatalf("user() empty = %q, want root", got)
+	}
+	if got := n.EffectiveUser(); got != "root" {
+		t.Fatalf("EffectiveUser() empty = %q, want root", got)
+	}
+	n.User = "alice"
+	if got := n.user(); got != "alice" {
+		t.Fatalf("user() = %q", got)
+	}
+	if got := n.EffectiveUser(); got != "alice" {
+		t.Fatalf("EffectiveUser() = %q", got)
+	}
+	n = &Node{}
+	if got := n.port(); got != 22 {
+		t.Fatalf("port() default = %d", got)
+	}
+	if got := n.SSHPort(); got != 22 {
+		t.Fatalf("SSHPort() default = %d", got)
+	}
+	for _, p := range []int{0, -1} {
+		n.Port = p
+		if got := n.port(); got != 22 {
+			t.Fatalf("port() for %d = %d, want 22", p, got)
+		}
+		if got := n.SSHPort(); got != 22 {
+			t.Fatalf("SSHPort() for %d = %d, want 22", p, got)
+		}
+	}
+	n.Port = 2222
+	if got := n.port(); got != 2222 {
+		t.Fatalf("port() = %d", got)
+	}
+	if got := n.SSHPort(); got != 2222 {
+		t.Fatalf("SSHPort() = %d", got)
+	}
+}
+
+func TestNode_JumpLabel(t *testing.T) {
+	t.Parallel()
+	n := &Node{}
+	if got := n.JumpLabel(); got != "" {
+		t.Fatalf("empty jump = %q", got)
+	}
+	n.Jump = []*Node{{Name: "hop", Host: "10.0.0.1"}}
+	if got := n.JumpLabel(); got != "hop" {
+		t.Fatalf("JumpLabel = %q, want hop", got)
+	}
+	n.Jump = []*Node{{Host: "10.0.0.2"}}
+	if got := n.JumpLabel(); got != "10.0.0.2" {
+		t.Fatalf("JumpLabel = %q", got)
+	}
+}
+
+func TestFindConnectableByNameOrAlias(t *testing.T) {
+	t.Parallel()
+	tree := []*Node{
+		{
+			Name: "g",
+			Children: []*Node{
+				{Name: "a1", Host: "h1", Alias: "alpha"},
+				{Name: "a2", Host: "h2"},
+				{Name: "dir", Children: []*Node{{Name: "leaf", Host: "h3"}}},
+			},
+		},
+	}
+	tests := []struct {
+		token string
+		want  int
+	}{
+		{"a1", 1},
+		{"alpha", 1},
+		{"leaf", 1},
+		{"missing", 0},
+		{"g", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			got := FindConnectableByNameOrAlias(tree, tt.token)
+			if len(got) != tt.want {
+				t.Fatalf("len = %d, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfigBytes_absolutePath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "cfg.yaml")
+	content := []byte("hello")
+	if err := os.WriteFile(p, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadConfigBytes(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("content = %q, want %q", got, content)
+	}
+}
+
+func TestLoadConfigBytes_firstMatchWins(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	p1 := filepath.Join(dir, "first")
+	p2 := filepath.Join(dir, "second")
+	_ = os.WriteFile(p1, []byte("one"), 0o600)
+	_ = os.WriteFile(p2, []byte("two"), 0o600)
+	got, err := LoadConfigBytes(p1, p2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "one" {
+		t.Fatalf("got %q, want one", got)
+	}
+}
+
+func TestLoadConfigBytes_notFound(t *testing.T) {
+	t.Parallel()
+	_, err := LoadConfigBytes(filepath.Join(t.TempDir(), "nope-not-exists"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/tui/health.go
+++ b/internal/tui/health.go
@@ -1,8 +1,8 @@
 package tui
 
 import (
+	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"time"
 
@@ -64,11 +64,7 @@ type healthCheckResultMsg struct {
 
 func checkHostCmd(node *sshw.Node, gen int) tea.Cmd {
 	return func() tea.Msg {
-		port := node.Port
-		if port <= 0 {
-			port = 22
-		}
-		addr := net.JoinHostPort(node.Host, strconv.Itoa(port))
+		addr := net.JoinHostPort(node.Host, fmt.Sprintf("%d", node.SSHPort()))
 		start := time.Now()
 		conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
 		latency := time.Since(start)

--- a/internal/tui/item.go
+++ b/internal/tui/item.go
@@ -31,10 +31,7 @@ func (i indexedLeafItem) FilterValue() string {
 
 func filterValueForIndexed(idx IndexedHost) string {
 	n := idx.Node
-	user := n.User
-	if user == "" {
-		user = "root"
-	}
+	user := n.EffectiveUser()
 	port := ""
 	if n.Port > 0 {
 		port = fmt.Sprintf("%d", n.Port)
@@ -91,10 +88,7 @@ func computeColumns(items []list.Item) columnWidths {
 		if w := lipgloss.Width(n.Host); w > cols.host {
 			cols.host = w
 		}
-		u := n.User
-		if u == "" {
-			u = "root"
-		}
+		u := n.EffectiveUser()
 		if w := lipgloss.Width(u); w > cols.user {
 			cols.user = w
 		}
@@ -248,183 +242,106 @@ func truncateWithWidth(s string, maxW int) string {
 	return string(result) + "…"
 }
 
-func (d compactDelegate) renderHost(w io.Writer, node *sshw.Node, sel bool, termWidth int) {
-	cols := d.cols
-
-	// Cap name column to avoid overflow on narrow terminals
-	nameW := cols.name + 2
-	maxNameW := termWidth/3 - 3
-	if nameW > maxNameW && maxNameW > 8 {
-		nameW = maxNameW
+func portDisplay(n *sshw.Node) string {
+	if n.Port > 0 && n.Port != 22 {
+		return fmt.Sprintf(":%d", n.Port)
 	}
-
-	name := node.Name
-	if lipgloss.Width(name) > nameW-2 {
-		name = truncateWithWidth(name, nameW-2)
-	}
-	host := node.Host
-	user := node.User
-	if user == "" {
-		user = "root"
-	}
-	port := ""
-	if node.Port > 0 && node.Port != 22 {
-		port = fmt.Sprintf(":%d", node.Port)
-	} else {
-		port = ":22"
-	}
-
-	var jump string
-	if len(node.Jump) > 0 {
-		jName := node.Jump[0].Name
-		if jName == "" {
-			jName = node.Jump[0].Host
-		}
-		jump = " → " + jName
-	}
-
-	nameCol := lipgloss.NewStyle().Width(nameW)
-	hostCol := lipgloss.NewStyle().Width(cols.host + 2)
-	userCol := lipgloss.NewStyle().Width(cols.user + 2)
-
-	aliasW := cols.alias
-	aliasCell := ""
-	if aliasW > 0 {
-		at := ""
-		if node.Alias != "" {
-			at = "@" + node.Alias
-			if lipgloss.Width(at) > aliasW {
-				at = truncateWithWidth(at, aliasW)
-			}
-		}
-		aliasCol := lipgloss.NewStyle().Width(aliasW + 1)
-		if sel {
-			aliasCell = aliasCol.Render(selAliasStyle.Render(at))
-		} else {
-			aliasCell = aliasCol.Render(norAliasStyle.Render(at))
-		}
-	}
-
-	var line string
-	if sel {
-		line = fmt.Sprintf("%s%s%s%s%s%s%s",
-			cursorStyle.Render(" ▸ "),
-			nameCol.Render(selNameStyle.Render(name)),
-			aliasCell,
-			hostCol.Render(selHostStyle.Render(host)),
-			userCol.Render(selUserStyle.Render(user)),
-			selPortStyle.Render(port),
-			selJumpStyle.Render(jump),
-		)
-	} else {
-		line = fmt.Sprintf("   %s%s%s%s%s%s",
-			nameCol.Render(norNameStyle.Render(name)),
-			aliasCell,
-			hostCol.Render(norHostStyle.Render(host)),
-			userCol.Render(norUserStyle.Render(user)),
-			norPortStyle.Render(port),
-			norJumpStyle.Render(jump),
-		)
-	}
-
-	if d.health != nil {
-		if r, ok := d.health.results[node]; ok {
-			line += renderHealthIndicator(r, d.health.spinner)
-		}
-	}
-
-	fmt.Fprint(w, applyRowHighlight(line, sel, termWidth))
+	return ":22"
 }
 
-func (d compactDelegate) renderIndexedLeaf(w io.Writer, idx IndexedHost, sel bool, termWidth int) {
-	n := idx.Node
+func jumpDisplay(n *sshw.Node) string {
+	if jl := n.JumpLabel(); jl != "" {
+		return " → " + jl
+	}
+	return ""
+}
+
+func aliasCellFor(cols *columnWidths, n *sshw.Node, sel bool) string {
+	aliasW := cols.alias
+	if aliasW <= 0 {
+		return ""
+	}
+	at := ""
+	if n.Alias != "" {
+		at = "@" + n.Alias
+		if lipgloss.Width(at) > aliasW {
+			at = truncateWithWidth(at, aliasW)
+		}
+	}
+	aliasCol := lipgloss.NewStyle().Width(aliasW + 1)
+	if sel {
+		return aliasCol.Render(selAliasStyle.Render(at))
+	}
+	return aliasCol.Render(norAliasStyle.Render(at))
+}
+
+// hostRowOpts tweaks layout between the normal host list row and the global palette row.
+type hostRowOpts struct {
+	breadcrumb string // non-empty enables breadcrumb prefix (global palette)
+	nameDenom  int    // termWidth/nameDenom - 3 caps name column; host list uses 3, global uses 4
+}
+
+func (o hostRowOpts) nameWidthDenom() int {
+	if o.nameDenom <= 0 {
+		return 3
+	}
+	return o.nameDenom
+}
+
+func (d compactDelegate) renderHostRow(w io.Writer, n *sshw.Node, sel bool, termWidth int, opts hostRowOpts) {
 	cols := d.cols
 
-	bc := idx.Breadcrumb
-	bcMax := max(0, termWidth/3)
-	if bc != "" && lipgloss.Width(bc) > bcMax {
-		bc = truncateWithWidth(bc, bcMax)
-	}
-
 	nameW := cols.name + 2
-	maxNameW := termWidth/4 - 3
+	maxNameW := termWidth/opts.nameWidthDenom() - 3
 	if nameW > maxNameW && maxNameW > 8 {
 		nameW = maxNameW
 	}
+
 	name := n.Name
 	if lipgloss.Width(name) > nameW-2 {
 		name = truncateWithWidth(name, nameW-2)
 	}
 	host := n.Host
-	user := n.User
-	if user == "" {
-		user = "root"
-	}
-	port := ""
-	if n.Port > 0 && n.Port != 22 {
-		port = fmt.Sprintf(":%d", n.Port)
-	} else {
-		port = ":22"
-	}
-	var jump string
-	if len(n.Jump) > 0 {
-		jName := n.Jump[0].Name
-		if jName == "" {
-			jName = n.Jump[0].Host
+	user := n.EffectiveUser()
+	port := portDisplay(n)
+	jump := jumpDisplay(n)
+
+	bcPrefix := ""
+	if opts.breadcrumb != "" {
+		bcMax := max(0, termWidth/3)
+		bc := opts.breadcrumb
+		if lipgloss.Width(bc) > bcMax {
+			bc = truncateWithWidth(bc, bcMax)
 		}
-		jump = " → " + jName
+		bcCol := lipgloss.NewStyle().Width(min(lipgloss.Width(bc)+2, bcMax+2))
+		bcPrefix = bcCol.Render(breadcrumbStyle.Render(bc)) + " "
 	}
 
-	bcCol := lipgloss.NewStyle().Width(min(lipgloss.Width(bc)+2, bcMax+2))
 	nameCol := lipgloss.NewStyle().Width(nameW)
 	hostCol := lipgloss.NewStyle().Width(cols.host + 2)
 	userCol := lipgloss.NewStyle().Width(cols.user + 2)
+	aliasCell := aliasCellFor(cols, n, sel)
 
-	aliasW := cols.alias
-	aliasCell := ""
-	if aliasW > 0 {
-		at := ""
-		if n.Alias != "" {
-			at = "@" + n.Alias
-			if lipgloss.Width(at) > aliasW {
-				at = truncateWithWidth(at, aliasW)
-			}
-		}
-		aliasCol := lipgloss.NewStyle().Width(aliasW + 1)
-		if sel {
-			aliasCell = aliasCol.Render(selAliasStyle.Render(at))
-		} else {
-			aliasCell = aliasCol.Render(norAliasStyle.Render(at))
-		}
-	}
-
-	bcPrefix := ""
-	if bc != "" {
-		bcPrefix = bcCol.Render(breadcrumbStyle.Render(bc)) + " "
+	cursorLead := "   "
+	if sel {
+		cursorLead = cursorStyle.Render(" ▸ ")
 	}
 
 	var line string
 	if sel {
-		line = fmt.Sprintf("%s%s%s%s%s%s%s%s",
-			cursorStyle.Render(" ▸ "),
-			bcPrefix,
-			nameCol.Render(selNameStyle.Render(name)),
-			aliasCell,
-			hostCol.Render(selHostStyle.Render(host)),
-			userCol.Render(selUserStyle.Render(user)),
-			selPortStyle.Render(port),
-			selJumpStyle.Render(jump),
-		)
+		line = cursorLead + bcPrefix +
+			nameCol.Render(selNameStyle.Render(name)) + aliasCell +
+			hostCol.Render(selHostStyle.Render(host)) +
+			userCol.Render(selUserStyle.Render(user)) +
+			selPortStyle.Render(port) +
+			selJumpStyle.Render(jump)
 	} else {
-		line = fmt.Sprintf("   %s%s%s%s%s%s%s",
-			bcPrefix,
-			nameCol.Render(norNameStyle.Render(name)),
-			aliasCell,
-			hostCol.Render(norHostStyle.Render(host)),
-			userCol.Render(norUserStyle.Render(user)),
-			norPortStyle.Render(port),
-			norJumpStyle.Render(jump),
-		)
+		line = cursorLead + bcPrefix +
+			nameCol.Render(norNameStyle.Render(name)) + aliasCell +
+			hostCol.Render(norHostStyle.Render(host)) +
+			userCol.Render(norUserStyle.Render(user)) +
+			norPortStyle.Render(port) +
+			norJumpStyle.Render(jump)
 	}
 
 	if d.health != nil {
@@ -434,4 +351,12 @@ func (d compactDelegate) renderIndexedLeaf(w io.Writer, idx IndexedHost, sel boo
 	}
 
 	fmt.Fprint(w, applyRowHighlight(line, sel, termWidth))
+}
+
+func (d compactDelegate) renderHost(w io.Writer, node *sshw.Node, sel bool, termWidth int) {
+	d.renderHostRow(w, node, sel, termWidth, hostRowOpts{nameDenom: 3})
+}
+
+func (d compactDelegate) renderIndexedLeaf(w io.Writer, idx IndexedHost, sel bool, termWidth int) {
+	d.renderHostRow(w, idx.Node, sel, termWidth, hostRowOpts{breadcrumb: idx.Breadcrumb, nameDenom: 4})
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,46 @@
+package tui
+
+import (
+	"testing"
+)
+
+func TestMatchMultiKeyword(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		input, content string
+		want           bool
+	}{
+		{"", "anything", true},
+		{"foo", "FooBar", true},
+		{"foo bar", "foo x bar", true},
+		{"foo bar", "foo only", false},
+		{"  a  b  ", "a and b", true},
+	}
+	for _, tc := range cases {
+		if got := matchMultiKeyword(tc.input, tc.content); got != tc.want {
+			t.Fatalf("matchMultiKeyword(%q,%q) = %v, want %v", tc.input, tc.content, got, tc.want)
+		}
+	}
+}
+
+func TestGlobalPaletteFilter(t *testing.T) {
+	t.Parallel()
+	targets := []string{"alpha beta", "gamma"}
+	r := globalPaletteFilter("alp", targets)
+	if len(r) != 1 || r[0].Index != 0 {
+		t.Fatalf("unexpected ranks: %#v", r)
+	}
+	r2 := globalPaletteFilter("alp bet", targets)
+	if len(r2) != 1 {
+		t.Fatalf("multi keyword: %#v", r2)
+	}
+}
+
+func TestMultiKeywordFilter(t *testing.T) {
+	t.Parallel()
+	targets := []string{"one two", "three"}
+	ranks := multiKeywordFilter("one two", targets)
+	if len(ranks) != 1 || ranks[0].Index != 0 {
+		t.Fatalf("ranks = %#v", ranks)
+	}
+}

--- a/log.go
+++ b/log.go
@@ -41,7 +41,7 @@ func (l *logger) Error(args ...interface{}) {
 }
 
 func (l *logger) Errorf(format string, args ...interface{}) {
-	l.printlnf("[level]", format, args...)
+	l.printlnf("[error]", format, args...)
 }
 
 func (l *logger) println(level string, args ...interface{}) {

--- a/log_test.go
+++ b/log_test.go
@@ -1,0 +1,55 @@
+package sshw
+
+import (
+	"log"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDefaultLogger_prefixes(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	old := stdlog
+	stdlog = log.New(w, "[sshw] ", 0)
+	defer func() { stdlog = old }()
+
+	done := make(chan struct{})
+	var out strings.Builder
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			if n > 0 {
+				out.Write(buf[:n])
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	lg := &logger{}
+	lg.Info("a", "b")
+	lg.Infof("x=%s", "y")
+	lg.Error("oops")
+	lg.Errorf("bad %d", 1)
+	_ = w.Close()
+	<-done
+
+	s := out.String()
+	if !strings.Contains(s, "[sshw]") || !strings.Contains(s, "[info]") {
+		t.Fatalf("expected sshw+info prefix in %q", s)
+	}
+	if !strings.Contains(s, "[error]") {
+		t.Fatalf("expected [error] in %q", s)
+	}
+	if strings.Contains(s, "[level]") {
+		t.Fatalf("unexpected legacy Errorf tag [level] in %q", s)
+	}
+}


### PR DESCRIPTION
## Summary

DRY-focused refactor of `sshw` + TUI, unit-test baseline, and README env docs (`SSHW_CONFIG_PATH`, `SSHW_SSH_CONFIG_PATH`).

## Notes

- Intended for this fork only (`Ehco1996/sshw`).


Made with [Cursor](https://cursor.com)