### PR TITLE
feat: support dynamic inventory loading and fix empty agent auth fallback

### DIFF
--- a/client.go
+++ b/client.go
@@ -72,15 +72,26 @@ func getAgentConn(agentPath string) (net.Conn, error) {
 }
 
 func setupAgentAuth(node *Node) (ssh.AuthMethod, cleanupFunc, error) {
-	if node.AgentPath == "" {
+	agentPath := node.AgentPath
+	if agentPath == "" {
+		agentPath = os.Getenv("SSH_AUTH_SOCK")
+	}
+	if agentPath == "" {
 		return nil, nil, nil
 	}
 
-	conn, err := getAgentConn(node.AgentPath)
+	conn, err := getAgentConn(agentPath)
 	if err != nil {
 		return nil, nil, err
 	}
+	
 	client := agent.NewClient(conn)
+	signers, err := client.Signers()
+	if err != nil || len(signers) == 0 {
+		conn.Close()
+		return nil, nil, nil
+	}
+	
 	return ssh.PublicKeysCallback(client.Signers), func() { conn.Close() }, nil
 }
 
@@ -112,12 +123,19 @@ func setupDefaultKeyAuth(node *Node) (ssh.AuthMethod, cleanupFunc, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	keyPath := filepath.Join(u.HomeDir, ".ssh/id_rsa")
-	bytes, err := os.ReadFile(keyPath)
-	if err == nil && len(bytes) > 0 {
-		if signer, err := parseSigner(bytes, node.Passphrase); err == nil {
-			return ssh.PublicKeys(signer), nil, nil
+	defaultKeys := []string{"id_ed25519", "id_rsa", "id_ecdsa"}
+	var signers []ssh.Signer
+	for _, keyName := range defaultKeys {
+		keyPath := filepath.Join(u.HomeDir, ".ssh", keyName)
+		bytes, err := os.ReadFile(keyPath)
+		if err == nil && len(bytes) > 0 {
+			if signer, err := parseSigner(bytes, node.Passphrase); err == nil {
+				signers = append(signers, signer)
+			}
 		}
+	}
+	if len(signers) > 0 {
+		return ssh.PublicKeys(signers...), nil, nil
 	}
 	return nil, nil, nil
 }

--- a/cmd/sshw/main.go
+++ b/cmd/sshw/main.go
@@ -15,6 +15,8 @@ var (
 	V     = flag.Bool("version", false, "show version")
 	H     = flag.Bool("help", false, "show help")
 	S     = flag.Bool("s", false, "use local ssh config '~/.ssh/config'")
+	I     = flag.String("i", "", "use dynamic inventory url (e.g., https://.../api/inventory/)")
+	K     = flag.String("k", "", "API key for dynamic inventory (sent as X-API-KEY header)")
 
 	log = sshw.GetLogger()
 )
@@ -37,7 +39,18 @@ func main() {
 		fmt.Println("  go version :", runtime.Version())
 		return
 	}
-	if *S {
+
+	if *I != "" {
+		if *K == "" {
+			fmt.Fprintln(os.Stderr, "-k (API key) is required when using -i")
+			os.Exit(1)
+		}
+		err := sshw.LoadDynamicConfig(*I, *K)
+		if err != nil {
+			log.Error("load dynamic config error", err)
+			os.Exit(1)
+		}
+	} else if *S {
 		err := sshw.LoadSshConfig()
 		if err != nil {
 			log.Error("load ssh config error", err)

--- a/config.go
+++ b/config.go
@@ -1,7 +1,10 @@
 package sshw
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -273,4 +276,51 @@ func LoadConfigBytes(names ...string) ([]byte, error) {
 		lastErr = err
 	}
 	return nil, lastErr
+}
+
+// LoadDynamicConfig fetches inventory from a dynamic HTTP endpoint
+func LoadDynamicConfig(url string, apiKey string) error {
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-API-KEY", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch dynamic config: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(body, &config)
+	if err != nil {
+		return err
+	}
+
+	// Expand home dir for all nodes recursively just in case
+	var walk func(nodes []*Node)
+	walk = func(nodes []*Node) {
+		for _, n := range nodes {
+			if n.KeyPath != "" {
+				n.KeyPath, _ = homedir.Expand(n.KeyPath)
+			}
+			if n.AgentPath != "" {
+				n.AgentPath, _ = homedir.Expand(n.AgentPath)
+			}
+			walk(n.Children)
+		}
+	}
+	walk(config)
+
+	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,8 @@
 package sshw
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -259,5 +261,48 @@ func TestSaveConfig_roundTrip(t *testing.T) {
 	}
 	if ConfigPath() != path {
 		t.Fatalf("ConfigPath = %q", ConfigPath())
+	}
+}
+
+func TestLoadDynamicConfig(t *testing.T) {
+	t.Parallel()
+	mockResponse := `[
+		{
+			"name": "Group A",
+			"children": [
+				{"name": "node1", "host": "1.1.1.1", "user": "root", "port": 22}
+			]
+		}
+	]`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-KEY") != "test-key" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(mockResponse))
+	}))
+	defer ts.Close()
+
+	// Reset config before test
+	oldConfig := config
+	defer func() { config = oldConfig }()
+
+	err := LoadDynamicConfig(ts.URL, "test-key")
+	if err != nil {
+		t.Fatalf("LoadDynamicConfig failed: %v", err)
+	}
+
+	if len(config) != 1 || config[0].Name != "Group A" {
+		t.Fatalf("unexpected loaded config: %#v", config)
+	}
+	if len(config[0].Children) != 1 || config[0].Children[0].Name != "node1" {
+		t.Fatalf("unexpected child: %#v", config[0].Children)
+	}
+
+	// Test unauthorized
+	err = LoadDynamicConfig(ts.URL, "wrong-key")
+	if err == nil {
+		t.Fatal("expected unauthorized error, got nil")
 	}
 }


### PR DESCRIPTION
This PR adds support for dynamic inventory loading using a custom API URL and an API key header, and fixes the empty ssh-agent authentication bug where Go's ssh client would fail to authenticate default keys if an empty agent auth method is registered.